### PR TITLE
Bump ameba to 1.2.0

### DIFF
--- a/.github/workflows/ci-crystal.yml
+++ b/.github/workflows/ci-crystal.yml
@@ -4,8 +4,8 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/ci-crystal.yml'
-      - 'spec/**'
-      - 'src/**'
+      - '**/*.cr'
+      - '**/*.ecr'
       - 'shard.yml'
       - 'shard.lock'
       - 'package.json'
@@ -14,8 +14,8 @@ on:
   pull_request:
     paths:
       - '.github/workflows/ci-crystal.yml'
-      - 'spec/**'
-      - 'src/**'
+      - '**/*.cr'
+      - '**/*.ecr'
       - 'shard.yml'
       - 'shard.lock'
       - 'package.json'
@@ -41,6 +41,7 @@ jobs:
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: '${{ fromJson(needs.asdf-parser.outputs.tool-versions).crystal }}'
+      - run: shards install
       # Need node.js to install validator. Spec includes the validator runner
       - uses: actions/setup-node@v3
         with:
@@ -48,3 +49,14 @@ jobs:
           cache: npm
       - run: npm ci
       - run: crystal spec
+  lint:
+    needs: [asdf-parser]
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: '${{ fromJson(needs.asdf-parser.outputs.tool-versions).crystal }}'
+      - run: shards install
+      - run: make crystal-lint-check

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: '${{ fromJson(needs.asdf-parser.outputs.tool-versions).crystal }}'
-      - run: make crystal-format-check
+      - run: make crystal-lint-check
   definitions:
     needs: [asdf-parser]
     timeout-minutes: 5

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,17 +28,6 @@ jobs:
       - uses: dprint/check@v2.1
         with:
           dprint-version: '${{ fromJson(needs.asdf-parser.outputs.tool-versions).dprint }}'
-  crystal:
-    needs: [asdf-parser]
-    timeout-minutes: 5
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: crystal-lang/install-crystal@v1
-        with:
-          crystal: '${{ fromJson(needs.asdf-parser.outputs.tool-versions).crystal }}'
-      - run: shards install
-      - run: make crystal-lint-check
   definitions:
     needs: [asdf-parser]
     timeout-minutes: 5
@@ -48,5 +37,6 @@ jobs:
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: '${{ fromJson(needs.asdf-parser.outputs.tool-versions).crystal }}'
+      - run: shards install
       - run: make build-tools
       - run: make lint-definitions

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,7 @@ jobs:
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: '${{ fromJson(needs.asdf-parser.outputs.tool-versions).crystal }}'
+      - run: shards install
       - run: make crystal-lint-check
   definitions:
     needs: [asdf-parser]

--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ lint-definitions:
 lint-all: crystal-lint-check dprint-check lint-definitions
 
 crystal-lint-check: crystal-format-check
-	bin/ameba
+	./bin/ameba
 
 .PHONY: crystal-format-check
 crystal-format-check:
@@ -56,7 +56,7 @@ lint-fix-all: crystal-lint-fix dprint-fix
 .PHONY: crystal-lint-fix
 crystal-lint-fix:
 	crystal tool format
-	bin/ameba --fix
+	./bin/ameba --fix
 
 .PHONY: dprint-fix
 dprint-fix:

--- a/shard.lock
+++ b/shard.lock
@@ -2,5 +2,5 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.1.0
+    version: 1.2.0
 

--- a/shard.yml
+++ b/shard.yml
@@ -15,7 +15,7 @@ authors:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.1.0
+    version: ~> 1.2.0
 
 license: MIT
 


### PR DESCRIPTION
Works, but shows warning when without this change.

```console
❯ shards install
Resolving dependencies
Fetching https://github.com/crystal-ameba/ameba.git
Using ameba (1.1.0)
Shard "ameba" may be incompatible with Crystal 1.6.1
```

https://github.com/crystal-ameba/ameba/pull/277