### PR TITLE
Add CI for examples/.tool-versions are already installable in asdf-plugins

### DIFF
--- a/.github/workflows/ci-tool-versions.yml
+++ b/.github/workflows/ci-tool-versions.yml
@@ -14,7 +14,7 @@ jobs:
         # Do not use `echo json=$(script)` syntax here. The script generates multilines.
         run: |
           echo 'json=' | tee --append $GITHUB_OUTPUT
-          git diff origin/main HEAD --word-diff --relative ./examples/.tool-versions | grep -F ']{+' | ruby -r json -e 'puts STDIN.each_line.map { |l| /\A(\S+\s+).*?\{\+([^\+]+)/.match(l).captures.join }.join("\n").to_json' | tee --append $GITHUB_OUTPUT
+          git diff origin/${{ github.base_ref }} HEAD --word-diff --relative ./examples/.tool-versions | grep -F ']{+' | ruby -r json -e 'puts STDIN.each_line.map { |l| /\A(\S+\s+).*?\{\+([^\+]+)/.match(l).captures.join }.join("\n").to_json' | tee --append $GITHUB_OUTPUT
       - uses: asdf-vm/actions/install@v1
         with:
           tool_versions: '${{ fromJson(steps.format-only-new-versions.outputs.json) }}'

--- a/.github/workflows/ci-tool-versions.yml
+++ b/.github/workflows/ci-tool-versions.yml
@@ -16,7 +16,7 @@ jobs:
         # Do not use `echo json=$(script)` syntax here. The script generates multilines.
         run: |
           tempfile="$(mktemp)"
-          echo 'json=' | tee --append "$tempfile"
+          echo -n 'json=' | tee --append "$tempfile"
           git diff origin/${{ github.base_ref }} HEAD --word-diff --relative ./examples/.tool-versions | grep -F ']{+' | ruby -r json -e 'puts STDIN.each_line.map { |l| /\A(\S+\s+).*?\{\+([^\+]+)/.match(l).captures.join }.join("\n").to_json' | tee --append "$tempfile"
           cat "$tempfile" | tee --append $GITHUB_OUTPUT
       - uses: asdf-vm/actions/install@v1

--- a/.github/workflows/ci-tool-versions.yml
+++ b/.github/workflows/ci-tool-versions.yml
@@ -15,8 +15,10 @@ jobs:
         id: format-only-new-versions
         # Do not use `echo json=$(script)` syntax here. The script generates multilines.
         run: |
-          echo 'json=' | tee --append $GITHUB_OUTPUT
-          git diff origin/${{ github.base_ref }} HEAD --word-diff --relative ./examples/.tool-versions | grep -F ']{+' | ruby -r json -e 'puts STDIN.each_line.map { |l| /\A(\S+\s+).*?\{\+([^\+]+)/.match(l).captures.join }.join("\n").to_json' | tee --append $GITHUB_OUTPUT
+          tempfile="$(mktemp)"
+          echo 'json=' | tee --append "$tempfile"
+          git diff origin/${{ github.base_ref }} HEAD --word-diff --relative ./examples/.tool-versions | grep -F ']{+' | ruby -r json -e 'puts STDIN.each_line.map { |l| /\A(\S+\s+).*?\{\+([^\+]+)/.match(l).captures.join }.join("\n").to_json' | tee --append "$tempfile"
+          cat "$tempfile" | tee --append $GITHUB_OUTPUT
       - uses: asdf-vm/actions/install@v1
         with:
           tool_versions: '${{ fromJson(steps.format-only-new-versions.outputs.json) }}'

--- a/.github/workflows/ci-tool-versions.yml
+++ b/.github/workflows/ci-tool-versions.yml
@@ -1,0 +1,20 @@
+name: CI - .tool-versions
+on:
+  pull_request:
+    paths:
+      - 'examples/.tool-versions'
+
+jobs:
+  installable:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v3
+      - id: format-only-new-versions
+        # Do not use `echo json=$(script)` syntax here. The script generates multilines.
+        run: |
+          echo 'json=' | tee --append $GITHUB_OUTPUT
+          git diff origin/main HEAD --word-diff --relative ./examples/.tool-versions | grep -F ']{+' | ruby -r json -e 'puts STDIN.each_line.map { |l| /\A(\S+\s+).*?\{\+([^\+]+)/.match(l).captures.join }.join("\n").to_json' | tee --append $GITHUB_OUTPUT
+      - uses: asdf-vm/actions/install@v1
+        with:
+          tool_versions: '${{ fromJson(steps.format-only-new-versions.outputs.json) }}'

--- a/.github/workflows/ci-tool-versions.yml
+++ b/.github/workflows/ci-tool-versions.yml
@@ -10,7 +10,9 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v3
-      - id: format-only-new-versions
+      - run: git fetch origin ${{ github.base_ref }} --depth=1
+      - name: Re-format only changed .tool-versions
+        id: format-only-new-versions
         # Do not use `echo json=$(script)` syntax here. The script generates multilines.
         run: |
           echo 'json=' | tee --append $GITHUB_OUTPUT

--- a/examples/.tool-versions
+++ b/examples/.tool-versions
@@ -10,7 +10,7 @@ elixir 1.14.1
 elm 0.19.1
 erlang 25.1.2
 gauche 0.9.12
-golang 1.42.7
+golang 1.18.6
 haskell 9.4.2
 helm 3.10.1
 helmfile 0.147.0

--- a/examples/.tool-versions
+++ b/examples/.tool-versions
@@ -10,11 +10,11 @@ elixir 1.14.1
 elm 0.19.1
 erlang 25.1.2
 gauche 0.9.12
-golang 1.19.2
+golang 1.42.7
 haskell 9.4.2
 helm 3.10.1
 helmfile 0.147.0
-hugo extended_0.104.3 0.105.0
+hugo extended_0.105.0 0.105.0
 idris 1.3.4
 julia 1.8.2
 just 1.7.0


### PR DESCRIPTION
Because of asdf-nodejs dependents node-build. Latest versions can not be installed by asdf-nodejs

And I would integrate faster automergers for all bot PRs, .tool-versions check is the last one of my worry.

---

## Cons

https://github.com/asdf-vm/actions/tree/171cc3570019f3a69ba10ae269ab46990936fa9f does not support git-url yet. So non registered https://github.com/asdf-vm/asdf-plugins/tree/master/plugins plugins will not work 
