### PR TITLE
Fix datasource because of asdf-helm depending github-releases

### DIFF
--- a/default.json
+++ b/default.json
@@ -98,7 +98,7 @@
       "fileMatch": ["\\.tool-versions$"],
       "matchStrings": ["(^|\\n)helm (?<currentValue>\\S+)"],
       "depNameTemplate": "helm/helm",
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>\\S+)"
     },
     {

--- a/plugins/helm.json5
+++ b/plugins/helm.json5
@@ -5,8 +5,13 @@
     {
       "fileMatch": ["\\.tool-versions$"],
       "matchStrings": ["(^|\\n)helm (?<currentValue>\\S+)"],
+      // Plugin Fetcher Permalink:
+      //   - https://github.com/asdf-vm/asdf-plugins/blob/82969331df11ba93e8bcfde89fc22da5f5874ac4/plugins/helm#L1
+      //   - https://github.com/Antiarchitect/asdf-helm/blob/a39e17b098523b3840c359055192751ae835f835/bin/list-all#L3
+      //   - https://github.com/Antiarchitect/asdf-helm/blob/a39e17b098523b3840c359055192751ae835f835/bin/install#L73
+      // DataSource URL: https://github.com/helm/helm/releases
       "depNameTemplate": "helm/helm",
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>\\S+)"
     }
   ]


### PR DESCRIPTION
#355 makes CI failure as https://github.com/kachick/renovate-config-asdf/actions/runs/3437886682/jobs/5733235831

```
/usr/bin/git clone --depth 1 --branch master https://github.com/asdf-vm/asdf.git /home/runner/.asdf
Cloning into '/home/runner/.asdf'...
/home/runner/.asdf/bin/asdf plugin-list
No plugins installed
Installing helm plugin...
/home/runner/.asdf/bin/asdf plugin-add helm
initializing plugin repository...Cloning into '/home/runner/.asdf/repository'...
/home/runner/.asdf/bin/asdf install
Downloading helm from https://get.helm.sh/helm-v3.10.2-linux-amd64.tar.gz to /tmp/helm_yKHI0x/helm-v3.10.2-linux-amd64.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   215  100   215    0     0    2[9](https://github.com/kachick/renovate-config-asdf/actions/runs/3437886682/jobs/5733235831#step:5:10)2      0 --:--:-- --:--:-- --:--:--   292
Creating bin directory
Cleaning previous binaries
Copying binary

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```

When looking into https://github.com/helm/helm/tags and https://github.com/helm/helm/releases, only tags updated. So replacing to releases as the datasource might be better. 

This PR updates #93