### PR TITLE
Disable official asdf manager in this repo to make stable test

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
     "github>kachick/renovate-config-dprint:plugins",
     "local>kachick/renovate-config-asdf"
   ],
+  "enabledManagers": ["npm", "github-actions", "regex"],
   "packageRules": [
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Following part of #378

Currently enabled official asdf managers makes unclear own definitions are worked or not.
So opt-out asdf manager to make stable tests. This does not affect for dependent repos.

refs:

- #106
- https://docs.renovatebot.com/modules/manager/