### PR TITLE
Prefer release rather than tags for Scala

### DIFF
--- a/default.json
+++ b/default.json
@@ -213,14 +213,14 @@
       "fileMatch": ["\\.tool-versions$"],
       "matchStrings": ["(^|\\n)scala (?<currentValue>2\\.\\S+)"],
       "depNameTemplate": "scala/scala",
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>\\S+)"
     },
     {
       "fileMatch": ["\\.tool-versions$"],
       "matchStrings": ["(^|\\n)scala (?<currentValue>3\\.\\S+)"],
       "depNameTemplate": "lampepfl/dotty",
-      "datasourceTemplate": "github-tags"
+      "datasourceTemplate": "github-releases"
     },
     {
       "fileMatch": ["\\.tool-versions$"],

--- a/plugins/scala.json5
+++ b/plugins/scala.json5
@@ -5,17 +5,17 @@
     {
       "fileMatch": ["\\.tool-versions$"],
       "matchStrings": ["(^|\\n)scala (?<currentValue>2\\.\\S+)"],
-      // https://github.com/scala/scala/tags
+      // https://github.com/scala/scala/releases
       "depNameTemplate": "scala/scala",
-      "datasourceTemplate": "github-tags",
+      "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>\\S+)"
     },
     {
       "fileMatch": ["\\.tool-versions$"],
       "matchStrings": ["(^|\\n)scala (?<currentValue>3\\.\\S+)"],
-      // https://github.com/lampepfl/dotty/tags
+      // https://github.com/lampepfl/dotty/releases
       "depNameTemplate": "lampepfl/dotty",
-      "datasourceTemplate": "github-tags"
+      "datasourceTemplate": "github-releases"
     }
   ]
 }


### PR DESCRIPTION
I found this in CI of #607

They does not yet release 3.2.2 even after tagged it.