### PR TITLE
Start using Nix

### DIFF
--- a/.github/workflows/ci-crystal.yml
+++ b/.github/workflows/ci-crystal.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: '${{ fromJson(needs.asdf-parser.outputs.tool-versions).crystal }}'
+          crystal: '1.7.1'
       # Need node.js to install validator. Spec includes the validator runner
       - run: crystal spec --tag '~needs_npm'
   lint:
@@ -39,10 +39,10 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ./bin/ameba
-          key: ameba-${{ runner.os }}-crystal_${{ fromJson(needs.asdf-parser.outputs.tool-versions).crystal }}-${{ hashFiles('shard.lock') }}
+          key: ameba-${{ runner.os }}-crystal_1.7.1-${{ hashFiles('shard.lock') }}
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: '${{ fromJson(needs.asdf-parser.outputs.tool-versions).crystal }}'
+          crystal: '1.7.1'
       - run: shards install
         if: steps.cache.outputs.cache-hit != 'true'
       - run: make crystal-lint-check

--- a/.github/workflows/ci-crystal.yml
+++ b/.github/workflows/ci-crystal.yml
@@ -19,17 +19,7 @@ on:
       - '.tool-versions'
 
 jobs:
-  asdf-parser:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v3
-      - uses: kachick/action-parse-asdf-tool-versions@v3
-        id: parse
-    outputs:
-      tool-versions: '${{ steps.parse.outputs.json }}'
   spec:
-    needs: [asdf-parser]
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:
@@ -40,7 +30,6 @@ jobs:
       # Need node.js to install validator. Spec includes the validator runner
       - run: crystal spec --tag '~needs_npm'
   lint:
-    needs: [asdf-parser]
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-official.yml
+++ b/.github/workflows/ci-official.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '${{ fromJson(needs.asdf-parser.outputs.tool-versions).nodejs }}'
+          node-version: '18.13.0'
           cache: npm
       - run: npm ci
       # renovate.json will always tested by the CLI

--- a/.github/workflows/ci-official.yml
+++ b/.github/workflows/ci-official.yml
@@ -21,18 +21,7 @@ on:
       - '.tool-versions'
 
 jobs:
-  asdf-parser:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v3
-      - uses: kachick/action-parse-asdf-tool-versions@v3
-        id: parse
-    outputs:
-      tool-versions: '${{ steps.parse.outputs.json }}'
-
   validate:
-    needs: [asdf-parser]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -19,17 +19,7 @@ on:
       - '.tool-versions'
 
 jobs:
-  asdf-parser:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v3
-      - uses: kachick/action-parse-asdf-tool-versions@v3
-        id: parse
-    outputs:
-      tool-versions: '${{ steps.parse.outputs.json }}'
   test:
-    needs: [asdf-parser]
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci-typescript.yml
+++ b/.github/workflows/ci-typescript.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '${{ fromJson(needs.asdf-parser.outputs.tool-versions).nodejs }}'
+          node-version: '18.13.0'
           cache: npm
       - run: npm ci
       - run: npx tsc

--- a/.github/workflows/lint-definition.yml
+++ b/.github/workflows/lint-definition.yml
@@ -19,6 +19,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: '${{ fromJson(needs.asdf-parser.outputs.tool-versions).crystal }}'
+          crystal: '1.7.1'
       - run: shards install --production
       - run: crystal run src/cli.cr -- lint

--- a/.github/workflows/lint-definition.yml
+++ b/.github/workflows/lint-definition.yml
@@ -12,17 +12,7 @@ on:
       - '.vscode'
       - '**/*.md'
 jobs:
-  asdf-parser:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v3
-      - uses: kachick/action-parse-asdf-tool-versions@v3
-        id: parse
-    outputs:
-      tool-versions: '${{ steps.parse.outputs.json }}'
   definitions:
-    needs: [asdf-parser]
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint-dprint.yml
+++ b/.github/workflows/lint-dprint.yml
@@ -17,4 +17,4 @@ jobs:
       - uses: actions/checkout@v3
       - uses: dprint/check@v2.1
         with:
-          dprint-version: '${{ fromJson(needs.asdf-parser.outputs.tool-versions).dprint }}'
+          dprint-version: '0.34.4'

--- a/.github/workflows/lint-dprint.yml
+++ b/.github/workflows/lint-dprint.yml
@@ -10,17 +10,7 @@ on:
       - 'LICENSE'
       - '.vscode'
 jobs:
-  asdf-parser:
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - uses: actions/checkout@v3
-      - uses: kachick/action-parse-asdf-tool-versions@v3
-        id: parse
-    outputs:
-      tool-versions: '${{ steps.parse.outputs.json }}'
   dprint:
-    needs: [asdf-parser]
     timeout-minutes: 5
     runs-on: ubuntu-latest
     steps:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,0 @@
-nodejs 18.13.0
-dprint 0.34.1
-crystal 1.7.1

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,6 +7,7 @@
     "crystal-lang-tools.crystal-lang",
     "veelenga.crystal-ameba",
     "ms-vscode.makefile-tools",
-    "dbaeumer.vscode-eslint"
+    "dbaeumer.vscode-eslint",
+    "jnoortheen.nix-ide"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,16 @@
   "typescript.tsdk": "node_modules/typescript/lib",
   "editor.defaultFormatter": "dprint.dprint",
   "editor.formatOnSave": true,
+  "[nix]": {
+    "editor.defaultFormatter": "jnoortheen.nix-ide"
+  },
+  "nix.serverPath": "nil",
+  "nix.enableLanguageServer": true,
+  "nix.serverSettings": {
+    "nil": {
+      "formatting": { "command": ["nixpkgs-fmt"] }
+    }
+  },
   "cSpell.words": [
     "adoptium",
     "awscli",

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,29 +6,17 @@ However when you would add new plugins into this repository from some reasons, t
 
 ## Setup environments
 
+Author is using [Nix](https://nixos.org/) to maintain this repository.
+Because of installing crystal vis asdf might made missing lib* packages.
+
 ```console
+$ nix-shell
+(First execution might take long time. Then execute prepared bash with nodejs, crystal and other tools.)
 $ make install-deps
-asdf install
-crystal 1.5.0 is already installed
-dprint 0.30.3 is already installed
-nodejs 18.7.0 is already installed
 npm install
-
-up to date, audited 691 packages in 1s
-
-145 packages are looking for funding
-  run `npm fund` for details
-
-found 0 vulnerabilities
-
 shards install
-Resolving dependencies
-Fetching https://github.com/crystal-ameba/ameba.git
-Installing ameba (1.1.0)
-Postinstall of ameba: make bin && make run_file
-Writing shard.lock
-
 shards build
+...
 ```
 
 ## Tools

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ However when you would add new plugins into this repository from some reasons, t
 ## Setup environments
 
 Author is using [Nix](https://nixos.org/) to maintain this repository.
-Because of installing crystal vis asdf might made missing lib* packages.
+Because of installing crystal via asdf-crystal often make missing lib* packages with depending the PKG_CONFIG.
 
 ```console
 $ nix-shell

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Because of installing crystal vis asdf might made missing lib* packages.
 ```console
 $ nix-shell
 (First execution might take long time. Then execute prepared bash with nodejs, crystal and other tools.)
-$ make install-deps
+$ make setup
 npm install
 shards install
 shards build

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,6 @@ test:
 
 .PHONY: install-deps
 install-deps:
-	asdf install
 	npm install
 	shards install
 	$(MAKE) build-tools

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ test:
 	npx ts-node-test test/*.ts
 	crystal spec
 
-.PHONY: install-deps
-install-deps:
+.PHONY: setup
+setup:
 	npm install
 	shards install
 	$(MAKE) build-tools

--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,10 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "dependencyDashboard": true,
   "extends": ["config:base", "github>kachick/renovate-config-dprint:plugins", "local>kachick/renovate-config-asdf"],
-  "enabledManagers": ["npm", "github-actions", "regex"],
+  "enabledManagers": ["npm", "nix", "github-actions", "regex"],
+  "nix": {
+    "enabled": true
+  },
   "packageRules": [
     {
       "matchPackagePatterns": ["*"],

--- a/shard.lock
+++ b/shard.lock
@@ -2,5 +2,5 @@ version: 2.0
 shards:
   ameba:
     git: https://github.com/crystal-ameba/ameba.git
-    version: 1.2.0
+    version: 1.3.1
 

--- a/shard.yml
+++ b/shard.yml
@@ -15,7 +15,7 @@ authors:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.2.0
+    version: ~> 1.3.1
 
 license: MIT
 

--- a/shell.nix
+++ b/shell.nix
@@ -4,8 +4,7 @@ pkgs.mkShell {
   buildInputs = [
     pkgs.nodejs-18_x
     pkgs.crystal_1_7
-    # pkgs.shards
-    # pkgs.glibc # Nidded in shards https://github.com/crystal-lang/crystal/issues/2114
+    pkgs.shards
     pkgs.dprint
     pkgs.nil
     pkgs.nixpkgs-fmt

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,11 @@
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/bbbcb362e8a623c8125bdccb72d2d6a874548862.tar.gz") { } }:
+
+pkgs.mkShell {
+  buildInputs = [
+    pkgs.nodejs-18_x
+    pkgs.crystal_1_7
+    pkgs.dprint
+    pkgs.nil
+    pkgs.nixpkgs-fmt
+  ];
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,4 +1,4 @@
-{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/bbbcb362e8a623c8125bdccb72d2d6a874548862.tar.gz") { } }:
+{ pkgs ? import (fetchTarball "https://github.com/NixOS/nixpkgs/archive/91c11d19e7007d768dff5d74daf2e6d704aeeebf.tar.gz") { } }:
 
 pkgs.mkShell {
   buildInputs = [

--- a/shell.nix
+++ b/shell.nix
@@ -4,6 +4,8 @@ pkgs.mkShell {
   buildInputs = [
     pkgs.nodejs-18_x
     pkgs.crystal_1_7
+    # pkgs.shards
+    # pkgs.glibc # Nidded in shards https://github.com/crystal-lang/crystal/issues/2114
     pkgs.dprint
     pkgs.nil
     pkgs.nixpkgs-fmt


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/195606
https://github.com/NixOS/nixpkgs/blob/f680c2020f41da5d2ed5d88ad3f997b9a8d03b77/pkgs/development/tools/build-managers/shards/default.nix

```
❯ nix-shell
this derivation will be built:
  /nix/store/5lixc94pfmzh2182gj1isnmprznn496d-shards-0.17.1.drv
building '/nix/store/5lixc94pfmzh2182gj1isnmprznn496d-shards-0.17.1.drv'...
unpacking sources
unpacking source archive /nix/store/88psdiw0237s45kzdzq62bksl3108r9c-source
source root is source
patching sources
configuring
building
impure path `/homeless-shelter/.cache/crystal/nix-store-y0d7bz11swwllz3kbhs69cgzydkl6y1l-crystal-1.7.1-lib-crystal-ecr-process.cr/macro_run' used in link
collect2: error: ld returned 1 exit status
Error: execution of command failed with code: 1: `gcc "${@}" -o /homeless-shelter/.cache/crystal/nix-store-y0d7bz11swwllz3kbhs69cgzydkl6y1l-crystal-1.7.1-lib-crystal-ecr-process.cr/macro_run  -rdynamic -L/nix/store/hv1759ns1c3kqnn7cc88k5kg9sg371hs-boehm-gc-8.2.2/lib -L/nix/store/lx2yaqgvxhcwj65w65q539c2rgxh2bb7-pcre-8.45/lib -L/nix/store/qhncf29llczfv2dxszh6b7z5hbgs57lf-libevent-2.1.12/lib -L/nix/store/dikh5c5871q79jvbk53l4y725bb7h400-libyaml-0.2.5/lib -L/nix/store/04c0b1rmi9r6k9sl69a4gw3mhp3b5q2n-zlib-1.2.13/lib -L/nix/store/hh9xk92wsslk3g2i84kgi84izmrs4dyz-libxml2-2.10.3/lib -L/nix/store/773pradjpvxgxgs0mcklisx8ly6k1r4f-openssl-3.0.7/lib -lm -lgc -lpthread -levent -lrt -lpthread -ldl`
[9/13] Semantic (main)
error: builder for '/nix/store/5lixc94pfmzh2182gj1isnmprznn496d-shards-0.17.1.drv' failed with exit code 1
```